### PR TITLE
Updated electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "ava": "^0.22.0",
-    "electron": "1.7.6",
+    "electron": "2.0.2",
     "make-dir": "^1.0.0"
   },
   "bin": {


### PR DESCRIPTION
I could not run tests on electron programs I was running because of features missing in the older version depended on by avaron